### PR TITLE
Fix for pokestops: Jsonify needs correct formatting correct. Document…

### DIFF
--- a/pogom/app.py
+++ b/pogom/app.py
@@ -42,7 +42,7 @@ class Pogom(Flask):
         return jsonify(Pokemon.get_active(None))
 
     def pokestops(self):
-        return jsonify(Pokestop.get())
+        return jsonify([p for p in Pokestop.get()])
 
 
     def gyms(self):


### PR DESCRIPTION
This pull request includes a

- [ ] Bug fix
- [ ] New feature
- [ ] Translation

The following changes were made

-
-
-

If this is related to an existing ticket, include a link to it as well.

…ed here: https://github.com/AHAAAAAAA/PokemonGo-Map/issues/774

Was getting this error:
    TypeError: 'ResultIterator' object is not iterable
    [        app] [  ERROR] Exception on /pokestops [GET]
    ....
    File "~/PokemonGo-Map/pogom/app.py", line 45, in pokestops
    return jsonify(Pokestop.get())